### PR TITLE
Update record matcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,4 +175,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.14.6
+   1.15.1

--- a/lib/rspec/matchers/update_record_matcher.rb
+++ b/lib/rspec/matchers/update_record_matcher.rb
@@ -1,37 +1,139 @@
-RSpec::Matchers.define :update_record do |resource, attributes|
+RSpec::Matchers.define :update_record do |resource, expected_attributes|
   supports_block_expectations
 
-  match do |actual|
-    if using_form?
-      allow(form_klass).to receive(:new).and_call_original
-      expect_any_instance_of(form_klass).to receive(:save).and_call_original
+  # Creating a proxy wrapper for form, with a minimum possible public API, to allow for proxying all method calls
+  class FormWrapper < BasicObject
+    def initialize(form_object, expected_attributes_keys, changed_attributes_reference, resource)
+      @form_object = form_object
+      @expected_attributes_keys = expected_attributes_keys
+      @changed_attributes_reference = changed_attributes_reference
+      @resource = resource
     end
 
-    first_attribute_key = attributes.keys.first
-    initial_matcher = change { resource.reload.public_send(first_attribute_key) }.to(attributes[first_attribute_key])
-    update_all_attributes = attributes.except(first_attribute_key).inject(initial_matcher) do |current_matcher, (attribute_name, expected_value)|
-      current_matcher.and change { resource.public_send(attribute_name) }.to(expected_value)
+    def method_missing(method_name, *args, &block)
+      initial_attributes = @expected_attributes_keys.each_with_object({}) do |attribute_name, attributes|
+        attributes[attribute_name] = @resource.public_send(attribute_name)
+      end
+
+      @form_object.send(method_name, *args, &block)
+      @resource.reload
+
+      @expected_attributes_keys.each do |attribute_name|
+        attribute_changed = initial_attributes[attribute_name] != @resource.public_send(attribute_name)
+
+        @changed_attributes_reference << attribute_name if attribute_changed
+      end
     end
-
-    expect { actual.call }.to update_all_attributes
-
-    if using_form?
-      expect(form_klass).to have_received(:new).with(have_attributes(id: resource.id), kind_of(Hash))
-    end
-
-    true
   end
 
-  def using_form(form_klass)
-    @form_klass = form_klass
+  match do |actual|
+    @failure_message = nil
+    @resource = resource
+    @expected_attributes = expected_attributes
+    @names_of_attributes_changed_by_form = Set.new
+
+    if using_form?
+      allow(form_class).to receive(:new).and_wrap_original do |method, *args, &block|
+        form_object = method.call(*args, &block)
+        FormWrapper.new(form_object, expected_attributes.keys, names_of_attributes_changed_by_form, resource)
+      end
+    end
+
+    @initial_attributes = current_attributes
+
+    actual.call
+    resource.reload
+
+    @final_attributes = current_attributes
+
+    check_if_attributes_were_changed_to_expected_values
+    check_if_attributes_were_changed_using_form if using_form?
+
+    failure_message.blank?
+  end
+
+  failure_message do
+    @failure_message
+  end
+
+  def using_form(form_class)
+    @form_class = form_class
     self
   end
 
   def using_form?
-    form_klass.present?
+    form_class.present?
   end
 
   private
 
-  attr_reader :form_klass, :form
+  attr_reader :form_class,
+              :resource,
+              :expected_attributes,
+              :names_of_attributes_changed_by_form,
+              :initial_attributes,
+              :final_attributes
+
+  def current_attributes
+    expected_attributes.keys.each_with_object({}) do |attribute_name, attributes|
+      attributes[attribute_name] = resource.public_send(attribute_name)
+    end
+  end
+
+  def add_error_message(message)
+    if failure_message.present?
+      failure_message << "\n" * 2
+    else
+      @failure_message = ""
+    end
+
+    failure_message << message
+  end
+
+  def check_if_attributes_were_changed_to_expected_values
+    attributes_not_changed_to_expected_values = expected_attributes.select do |attribute_name, expected_attribute_value|
+      final_attributes[attribute_name] != expected_attribute_value
+    end
+
+    return if attributes_not_changed_to_expected_values.blank?
+
+    messages = attributes_not_changed_to_expected_values.keys.map do |attribute_name|
+      message_attribute_not_changed_to_expected_value(attribute_name)
+    end
+
+    add_error_message <<~MESSAGE.strip.squeeze(" ")
+      Expected a record of a #{resource.class} class with id = #{resource.id} to be updated, but the following \
+      #{messages.one? ? "attribute was" : "attributes were"} not properly changed:
+      #{messages.join("\n")}
+    MESSAGE
+  end
+
+  def message_attribute_not_changed_to_expected_value(attribute_name)
+    initial_value = initial_attributes[attribute_name]
+    final_value = final_attributes[attribute_name]
+    expected_value = expected_attributes[attribute_name]
+
+    message = "#{attribute_name.to_s.inspect} from #{initial_value.inspect} to #{expected_value.inspect}"
+    message << " (it was changed to #{final_value.inspect})" if initial_value != final_value
+    message
+  end
+
+  def check_if_attributes_were_changed_using_form
+    changed_attributes = initial_attributes.select do |attribute_name, initial_attribute_value|
+      final_attributes[attribute_name] != initial_attribute_value
+    end
+
+    names_of_attributes_changed_not_by_form = Set.new(changed_attributes.keys) - names_of_attributes_changed_by_form
+
+    return if names_of_attributes_changed_not_by_form.blank?
+
+    messages = names_of_attributes_changed_not_by_form.map { |attribute_name| attribute_name.to_s.inspect }
+
+    add_error_message <<~MESSAGE.strip.squeeze(" ")
+      Expected a record of a #{resource.class} class with id = #{resource.id} to \
+      be updated using #{form_class}, but the following \
+      #{messages.one? ? "attribute was" : "attributes were"} changed by some other means:
+      #{messages.join("\n")}
+    MESSAGE
+  end
 end

--- a/spec/rspec/matchers/update_record_matcher_spec.rb
+++ b/spec/rspec/matchers/update_record_matcher_spec.rb
@@ -1,6 +1,318 @@
 require "spec_helper"
 require "support/controller_specs_boilerplate"
 
-describe "update_record matcher", type: :controller do
+class User < ActiveRecord::Base
+end
 
+describe "update_record matcher", type: :controller do
+  context "when controller updates a record with given attributes" do
+    controller do
+      def update
+        User.find(params[:id]).update(user_params)
+      end
+
+      private
+
+      def user_params
+        params.require(:user).permit(:name, :age)
+      end
+    end
+
+    it "ensures that appropriate record is updated with the correct attributes" do
+      user = User.create(name: "Sophia", age: 20)
+
+      params = {
+        id: user.id,
+        user: {
+          name: "Emily",
+          age: 30
+        }
+      }
+
+      expect do
+        post(:update, params: params)
+      end.to update_record(user, name: "Emily", age: 30)
+    end
+  end
+
+  context "when controller does not update" do
+    controller do
+      def update
+        User.find(params[:id]).update(name: "Emily")
+      end
+    end
+
+    it "fails with a proper message if an attributes is not updated" do
+      user = User.create(name: "Sophia", age: 20)
+
+      params = {
+        id: user.id,
+        user: {
+          name: "Emily",
+          age: 30
+        }
+      }
+
+      expect do
+        expect do
+          post(:update, params: params)
+        end.to update_record(user, name: "Emily", age: 30)
+      end.to fail_with <<~MESSAGE.strip.squeeze(" ")
+        Expected a record of a User class with id = #{user.id} to be updated, \
+        but the following attribute was not properly changed:
+        "age" from 20 to 30
+      MESSAGE
+    end
+
+    it "fails with a proper messages if more than one attribute is not updated" do
+      user = User.create(name: "Sophia", age: 20)
+
+      params = {
+        id: user.id,
+        user: {
+          name: "Diana",
+          age: 30
+        }
+      }
+
+      expect do
+        expect do
+          post(:update, params: params)
+        end.to update_record(user, name: "Diana", age: 30)
+      end.to fail_with <<~MESSAGE.strip.squeeze(" ")
+        Expected a record of a User class with id = #{user.id} to be updated, \
+        but the following attributes were not properly changed:
+        "name" from "Sophia" to "Diana" (it was changed to "Emily")
+        "age" from 20 to 30
+      MESSAGE
+    end
+  end
+
+  context "when record is updated using proper form object" do
+    controller do
+      def update
+        UserForm.new(user, user_params).save
+      end
+
+      def update_with_fireworks
+        UserForm.new(user, user_params).update_with_fireworks
+      end
+
+      def update_age
+        UserForm.new(user, user_params).update_age
+      end
+
+      def update_name
+        UserForm.new(user, user_params).update_name
+      end
+
+      private
+
+      def user
+        User.find(params[:id])
+      end
+
+      def user_params
+        params.require(:user).permit(:name, :age)
+      end
+    end
+
+    before do
+      routes.draw do
+        post "update" => "anonymous#update"
+        post "update_with_fireworks" => "anonymous#update_with_fireworks"
+        post "update_age" => "anonymous#update_age"
+        post "update_name" => "anonymous#update_name"
+      end
+    end
+
+    class UserForm
+      def initialize(user, new_attributes)
+        @user = user
+        @new_attributes = new_attributes
+      end
+
+      def save
+        user.update(new_attributes)
+      end
+
+      def update_with_fireworks
+        # Here be dragons
+        user.update(new_attributes)
+      end
+
+      def update_age
+        user.update(new_attributes.slice(:age))
+      end
+
+      def update_name
+        user.update(new_attributes.slice(:name))
+      end
+
+      private
+
+      attr_reader :user, :new_attributes
+    end
+
+    it "ensures that appropriate object is updated using appropriate form object" do
+      user = User.create(name: "Emily", age: 20)
+      params = {
+        id: user.id,
+        user: {
+          name: "Sophie",
+          age: 30
+        }
+      }
+
+      expect do
+        post(:update, params: params)
+      end.to update_record(user, name: "Sophie", age: 30).using_form(UserForm)
+    end
+
+    it "does not assume any specific form object interface name" do
+      user = User.create(name: "Emily", age: 20)
+      params = {
+        id: user.id,
+        user: {
+          name: "Sophie",
+          age: 30
+        }
+      }
+
+      expect do
+        post(:update_with_fireworks, params: params)
+      end.to update_record(user, name: "Sophie", age: 30).using_form(UserForm)
+    end
+
+    it "does not assume a single form object method call" do
+      user = User.create(name: "Emily", age: 20)
+      params = {
+        id: user.id,
+        user: {
+          name: "Sophie",
+          age: 30
+        }
+      }
+
+      expect do
+        post(:update_age, params: params)
+        post(:update_name, params: params)
+      end.to update_record(user, name: "Sophie", age: 30).using_form(UserForm)
+    end
+  end
+
+  context "when record is updated without using proper form object" do
+    controller do
+      def update_one_with_form
+        UserForm.new(user, user_params.slice(:name)).save
+        user.update(user_params.slice(:age))
+      end
+
+      def update_without_form
+        user.update(user_params)
+      end
+
+      private
+
+      def user
+        User.find(params[:id])
+      end
+
+      def user_params
+        params.require(:user).permit(:name, :age)
+      end
+    end
+
+    before do
+      routes.draw do
+        post "update_one_with_form" => "anonymous#update_one_with_form"
+        post "update_without_form" => "anonymous#update_without_form"
+      end
+    end
+
+    class UserForm
+      def initialize(user, new_attributes)
+        @user = user
+        @new_attributes = new_attributes
+      end
+
+      def save
+        user.update(new_attributes)
+      end
+
+      private
+
+      attr_reader :user, :new_attributes
+    end
+
+    it "fails with a proper message if an attribute is updated without using proper form object" do
+      user = User.create(name: "Emily", age: 20)
+      params = {
+        id: user.id,
+        user: {
+          name: "Sophie",
+          age: 30
+        }
+      }
+
+      expect do
+        expect do
+          post(:update_one_with_form, params: params)
+        end.to update_record(user, name: "Sophie", age: 30).using_form(UserForm)
+      end.to fail_with <<~MESSAGE.strip.squeeze(" ")
+        Expected a record of a User class with id = #{user.id} to be updated using UserForm, \
+        but the following attribute was changed by some other means:
+        "age"
+      MESSAGE
+    end
+
+    it "fails with a proper message if all attributes are updated without using proper form object" do
+      user = User.create(name: "Emily", age: 20)
+      params = {
+        id: user.id,
+        user: {
+          name: "Sophie",
+          age: 30
+        }
+      }
+
+      expect do
+        expect do
+          post(:update_without_form, params: params)
+        end.to update_record(user, name: "Sophie", age: 30).using_form(UserForm)
+      end.to fail_with <<~MESSAGE.strip.squeeze(" ")
+        Expected a record of a User class with id = #{user.id} to be updated using UserForm, \
+        but the following attributes were changed by some other means:
+        "name"
+        "age"
+      MESSAGE
+    end
+
+    it "fails with a proper message if attributes are updated to a wrong value and without form" do
+      user = User.create(name: "Emily", age: 20)
+      params = {
+        id: user.id,
+        user: {
+          name: "Diana",
+          age: 25
+        }
+      }
+
+      expect do
+        expect do
+          post(:update_without_form, params: params)
+        end.to update_record(user, name: "Sophie", age: 30).using_form(UserForm)
+      end.to fail_with <<~MESSAGE.strip.squeeze(" ")
+        Expected a record of a User class with id = #{user.id} to be updated, \
+        but the following attributes were not properly changed:
+        "name" from "Emily" to "Sophie" (it was changed to "Diana")
+        "age" from 20 to 30 (it was changed to 25)
+
+        Expected a record of a User class with id = #{user.id} to be updated using UserForm, \
+        but the following attributes were changed by some other means:
+        "name"
+        "age"
+      MESSAGE
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/Selleo/rspec-controller-matchers/issues/5
Bonus task is accomplished by wrapping form objects with a very small proxy objects, which registers changed attributes on each call - in that way, we do not assume anything from form object interface other than that it is actually updating our resource.